### PR TITLE
feat(handshake): Improve handshake error handling... actually check the response

### DIFF
--- a/src/protocols/handshake.rs
+++ b/src/protocols/handshake.rs
@@ -16,6 +16,15 @@ use serde_cbor::{de, ser, Value};
 
 use crate::{Agency, Protocol};
 
+const PROTOCOL_VERSION_1: i128 = 0x01;
+const PROTOCOL_VERSION_2: i128 = 0x02;
+const PROTOCOL_VERSION_SHELLEY: i128 = 0x03;
+const PROTOCOL_VERSION_SHELLEY2: i128 = 0x04;
+const PROTOCOL_VERSION_ALLEGRA: i128 = 0x05;
+const MIN_PROTOCOL_VERSION: i128 = PROTOCOL_VERSION_ALLEGRA;
+
+const MSG_ACCEPT_VERSION_MSG_ID: i128 = 1;
+
 #[derive(Debug)]
 pub enum State {
     Propose,
@@ -43,8 +52,11 @@ impl HandshakeProtocol {
     // Create the byte representation of MsgProposeVersions for sending to the server
     fn msg_propose_versions(&self, network_magic: u32) -> Vec<u8> {
         let mut payload_map: BTreeMap<Value, Value> = BTreeMap::new();
-        // protocol version 3 mapped to the network_magic value
-        payload_map.insert(Value::Integer(0x03), Value::Integer(network_magic as i128));
+        payload_map.insert(Value::Integer(PROTOCOL_VERSION_1), Value::Integer(network_magic as i128));
+        payload_map.insert(Value::Integer(PROTOCOL_VERSION_2), Value::Integer(network_magic as i128));
+        payload_map.insert(Value::Integer(PROTOCOL_VERSION_SHELLEY), Value::Integer(network_magic as i128));
+        payload_map.insert(Value::Integer(PROTOCOL_VERSION_SHELLEY2), Value::Array(vec![Value::Integer(network_magic as i128), Value::Bool(false)]));
+        payload_map.insert(Value::Integer(PROTOCOL_VERSION_ALLEGRA), Value::Array(vec![Value::Integer(network_magic as i128), Value::Bool(false)]));
 
         let message = Value::Array(vec![
             Value::Integer(0), // message_id
@@ -71,6 +83,78 @@ impl HandshakeProtocol {
             _ => {}
         }
         return Err(());
+    }
+
+    fn validate_data(&self, confirm: Value, hex_data: String) -> Result<String, String> {
+        let confirm_vec = match &confirm {
+            Value::Array(confirm_vec) => { Ok(confirm_vec) }
+            _ => { Err(format!("Unable to parse payload error! {}", hex_data)) }
+        }?;
+
+        let msg_type = match confirm_vec.get(0) {
+            Some(msg_type) => { Ok(msg_type) }
+            None => { Err(format!("Unable to parse payload error! {}", hex_data)) }
+        }?;
+
+        let _msg_type_int = match msg_type {
+            Value::Integer(msg_type_int) => {
+                if *msg_type_int == MSG_ACCEPT_VERSION_MSG_ID {
+                    Ok(msg_type_int)
+                } else {
+                    match self.find_error_message(&confirm) {
+                        Ok(error_message) => {
+                            Err(error_message)
+                        }
+                        Err(_) => { Err(format!("Unable to parse payload error! {}", hex_data)) }
+                    }
+                }
+            }
+            _ => { Err(format!("Unable to parse payload error! {}", hex_data)) }
+        }?;
+
+        let accepted_protocol_value = match confirm_vec.get(1) {
+            Some(accepted_protocol_value) => { Ok(accepted_protocol_value) }
+            None => { Err(format!("Unable to parse payload error! {}", hex_data)) }
+        }?;
+
+        let _accepted_protocol = match accepted_protocol_value {
+            Value::Integer(accepted_protocol) => {
+                if *accepted_protocol < MIN_PROTOCOL_VERSION {
+                    Err(format!("Expected protocol version {}, but was {}", MIN_PROTOCOL_VERSION, accepted_protocol))
+                } else {
+                    Ok(accepted_protocol)
+                }
+            }
+            _ => { Err(format!("Unable to parse payload error! {}", hex_data)) }
+        }?;
+
+        let accepted_vec_value = match confirm_vec.get(2) {
+            Some(accepted_vec_value) => { Ok(accepted_vec_value) }
+            None => { Err(format!("Unable to parse payload error! {}", hex_data)) }
+        }?;
+
+        let accepted_vec = match accepted_vec_value {
+            Value::Array(accepted_vec) => { Ok(accepted_vec) }
+            _ => { Err(format!("Unable to parse payload error! {}", hex_data)) }
+        }?;
+
+        let accepted_magic_value = match accepted_vec.get(0) {
+            Some(accepted_magic_value) => { Ok(accepted_magic_value) }
+            None => { Err(format!("Unable to parse payload error! {}", hex_data)) }
+        }?;
+
+        let _accepted_magic = match accepted_magic_value {
+            Value::Integer(accepted_magic) => {
+                if *accepted_magic == self.network_magic as i128 {
+                    Ok(accepted_magic)
+                } else {
+                    Err(format!("Expected network magic {}, but was {}", self.network_magic, accepted_magic))
+                }
+            }
+            _ => { Err(format!("Unable to parse payload error! {}", hex_data)) }
+        }?;
+
+        return Ok(hex_data);
     }
 }
 
@@ -115,20 +199,10 @@ impl Protocol for HandshakeProtocol {
     }
 
     fn receive_data(&mut self, data: Vec<u8>) {
-        if data.len() != 8 {
-            // some payload error
-            let cbor_value: Value = de::from_slice(&data[..]).unwrap();
-            match self.find_error_message(&cbor_value) {
-                Ok(error_message) => {
-                    self.result = Some(Err(error_message));
-                }
-                Err(_) => {
-                    self.result = Some(Err(format!("Unable to parse payload error! {}", hex::encode(data))));
-                }
-            }
-        } else {
-            self.result = Some(Ok(hex::encode(data)));
-        }
+        let confirm: Value = de::from_slice(&data[..]).unwrap();
+        debug!("Confirm: {:?}", &confirm);
+        self.result = Some(self.validate_data(confirm, hex::encode(data)));
+
         debug!("HandshakeProtocol::State::Done");
         self.state = State::Done
     }


### PR DESCRIPTION
We were currently doing a very dumb check on the payload size to determine if a handshake is successful. I've implemented some parsing of the response to validate that a node is in the Allegra era for protocol version and also validate that the network magic value is matching.