### PR TITLE
fix: Agency issues with TxSubmissionProtocol

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@ use crate::{
     storage::msg_roll_forward::{MsgRollForward, Tip},
 };
 
-
 pub trait Protocol {
     // Each protocol has a unique hardcoded id
     fn protocol_id(&self) -> u16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,15 +9,16 @@ SPDX-License-Identifier: GPL-3.0-only OR LGPL-3.0-only
 
 */
 
+pub mod mux;
+pub mod protocols;
+pub mod storage;
+
 use std::io;
 
 use crate::{
     storage::msg_roll_forward::{MsgRollForward, Tip},
 };
 
-pub mod mux;
-pub mod protocols;
-pub mod storage;
 
 pub trait Protocol {
     // Each protocol has a unique hardcoded id

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,14 +9,15 @@ SPDX-License-Identifier: GPL-3.0-only OR LGPL-3.0-only
 
 */
 
-pub mod mux;
-pub mod protocols;
-pub mod storage;
-
 use std::io;
+
 use crate::{
     storage::msg_roll_forward::{MsgRollForward, Tip},
 };
+
+pub mod mux;
+pub mod protocols;
+pub mod storage;
 
 pub trait Protocol {
     // Each protocol has a unique hardcoded id

--- a/src/mux/tcp.rs
+++ b/src/mux/tcp.rs
@@ -63,18 +63,26 @@ impl Channel {
             shared.protocols[id] = Rc::downgrade(&proto);
         }
         loop {
-            if proto.borrow_mut().get_agency() == Agency::None {
+            let agency = proto.borrow_mut().get_agency();
+            if agency == Agency::None {
                 return match Rc::try_unwrap(proto) {
                     Ok(protocol) => protocol.into_inner().result(),
                     Err(_) => panic!("Unexpected reference to a subchannel."),
-                }
+                };
             }
 
             {
                 let mut shared = shared.borrow_mut();
                 /* TODO: Consider using async operations and select! */
-                shared.process_tx().await;
-                shared.process_rx().await;
+                match agency {
+                    Agency::Client => {
+                        shared.process_tx().await;
+                    }
+                    Agency::Server => {
+                        shared.process_rx().await;
+                    }
+                    Agency::None => {}
+                }
             }
         }
     }
@@ -94,18 +102,22 @@ impl ChannelShared {
                     let mut protocol = protocol.borrow_mut();
                     match protocol.get_agency() {
                         Agency::Client => {
-                            let payload = protocol.send_data().unwrap();
-                            let id = protocol.protocol_id();
-                            let mut msg = Vec::new();
-                            msg.write_u32::<NetworkEndian>(self.start_time.elapsed().as_micros() as u32).unwrap();
-                            msg.write_u16::<NetworkEndian>(id).unwrap();
-                            msg.write_u16::<NetworkEndian>(payload.len() as u16).unwrap();
-                            msg.write(&payload[..]).unwrap();
-                            /* TODO:
-                             *   * Asynchronous Tx.
-                             *   * Handle errors.
-                             */
-                            self.stream.write(&msg).unwrap();
+                            match protocol.send_data() {
+                                Some(payload) => {
+                                    let id = protocol.protocol_id();
+                                    let mut msg = Vec::new();
+                                    msg.write_u32::<NetworkEndian>(self.start_time.elapsed().as_micros() as u32).unwrap();
+                                    msg.write_u16::<NetworkEndian>(id).unwrap();
+                                    msg.write_u16::<NetworkEndian>(payload.len() as u16).unwrap();
+                                    msg.write(&payload[..]).unwrap();
+                                    /* TODO:
+                                     *   * Asynchronous Rx.
+                                     *   * Handle errors.
+                                     */
+                                    self.stream.write(&msg).unwrap();
+                                }
+                                _ => {}
+                            }
                         }
                         _ => {}
                     }
@@ -115,23 +127,46 @@ impl ChannelShared {
         }
     }
     async fn process_rx(&mut self) {
-        let mut header = [0u8; 8];
-        /* TODO:
+        let mut should_receive = false;
+        for subchannel in &self.protocols {
+            match subchannel.upgrade() {
+                Some(protocol) => {
+                    let protocol = protocol.borrow();
+                    match protocol.get_agency() {
+                        Agency::Server => {
+                            // at least one protocol has server agency
+                            should_receive = true;
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if should_receive {
+            let mut header = [0u8; 8];
+            /* TODO:
          *   * Asynchronous Rx.
          *   * Handle errors.
          */
-        self.stream.read_exact(&mut header).unwrap(); // TODO: Handle/ignore error.
-        let length = NetworkEndian::read_u16(&header[6..]) as usize;
-        let mut payload = vec![0u8; length];
-        self.stream.read_exact(&mut payload).unwrap(); // TODO: Handle/ignore error.
-        let _timestamp = NetworkEndian::read_u32(&mut header[0..4]);
-        let idx = NetworkEndian::read_u16(&mut header[4..6]) as usize ^ 0x8000;
-        match self.lookup(idx) {
-            Some(cell) => {
-                let mut protocol = cell.borrow_mut();
-                protocol.receive_data(payload);
+            let len = self.stream.peek(&mut header).unwrap();
+            if len >= header.len() {
+                self.stream.read_exact(&mut header).unwrap(); // TODO: Handle/ignore error.
+                let length = NetworkEndian::read_u16(&header[6..]) as usize;
+                let mut payload = vec![0u8; length];
+                self.stream.read_exact(&mut payload).unwrap(); // TODO: Handle/ignore error.
+                let _timestamp = NetworkEndian::read_u32(&mut header[0..4]);
+                let idx = NetworkEndian::read_u16(&mut header[4..6]) as usize ^ 0x8000;
+                match self.lookup(idx) {
+                    Some(cell) => {
+                        let mut protocol = cell.borrow_mut();
+                        protocol.receive_data(payload);
+                    }
+                    None => {}
+                }
             }
-            None => {}
         }
     }
     fn lookup(&self, id: usize) -> Option<Rc<RefCell<Box<dyn Protocol>>>> {

--- a/src/protocols/transaction.rs
+++ b/src/protocols/transaction.rs
@@ -60,13 +60,11 @@ impl Protocol for TxSubmissionProtocol {
     fn get_agency(&self) -> Agency {
         return match self.state {
             State::Idle => { Agency::Server }
-            State::TxIdsBlocking => {
-                // Typically, this would be client agency, but we pretend it's none since
-                // we just hang on to Client agency and never send any transactions.
-                Agency::None
-            }
+            State::TxIdsBlocking => { Agency::Client }
             State::TxIdsNonBlocking => { Agency::Client }
-            State::Done => { Agency::None }
+            State::Done => {
+                if self.result.is_none() { Agency::Client } else { Agency::None }
+            }
         };
     }
 
@@ -91,13 +89,13 @@ impl Protocol for TxSubmissionProtocol {
                 // Tell the server that we have no transactions to send them
                 let payload = self.msg_reply_tx_ids();
                 self.state = State::Idle;
-                return Some(payload);
+                Some(payload)
             }
             //State::Txs => { None }
             State::Done => {
                 warn!("TxSubmissionProtocol::State::Done");
                 self.result = Option::Some(Ok(String::from("Done")));
-                return None;
+                None
             }
         };
     }


### PR DESCRIPTION
TxSubmissionProtocol was having some issues for me since it has client agency, but we don't actually want to send anything. I modified `tcp.rs` a bit so that we don't require a payload for `process_tx()`. sync command is able to work for me in cncli now after this fix.