### PR TITLE
fix: Allow sync to succeed by skipping byron blocks

### DIFF
--- a/src/storage/msg_roll_backward.rs
+++ b/src/storage/msg_roll_backward.rs
@@ -16,9 +16,11 @@ pub fn parse_msg_roll_backward(cbor_array: Vec<Value>) -> i64 {
     let mut slot: i64 = 0;
     match &cbor_array[1] {
         Value::Array(block) => {
-            match block[0] {
-                Value::Integer(parsed_slot) => { slot = parsed_slot as i64 }
-                _ => { error!("invalid cbor"); }
+            if block.len() > 0 {
+                match block[0] {
+                    Value::Integer(parsed_slot) => { slot = parsed_slot as i64 }
+                    _ => { error!("invalid cbor"); }
+                }
             }
         }
         _ => { error!("invalid cbor"); }


### PR DESCRIPTION
Allow us to connect to new networks even though we don't yet properly parse byron blocks. Just skip them for now if we come across them. This PR allows us to sync against the launchpad network without specifically knowing or hardcoding the hash of its first shelley block. 