### PR TITLE
fix: Run save block callback before tip callback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub trait BlockStore {
     fn load_blocks(&mut self) -> Option<Vec<(i64, Vec<u8>)>>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BlockHeader {
     pub block_number: i64,
     pub slot_number: i64,


### PR DESCRIPTION
In CNCLI, I'm working on https://github.com/AndrewWestberg/cncli/issues/19

This allows the sync process to exit once we're on tip. We need to swap the order of the save block callback and the notify tip callback so we don't notify that we're on tip until AFTER the block has been saved. This allows the consumer (cncli in this case) to cleanly exit from the notify tip callback and know that all the data has already been saved.