### PR TITLE
fix(release): Bump version to 0.2.2

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -42,10 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-          toolchain: stable
-          override: true
     - uses: katyo/publish-crates@v1
       with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cardano_ouroboros_network"
 license = "GPL-3.0 OR LGPL-3.0-only"
-version = "0.2.0"
+version = "0.2.2"
 authors = [
   "Mark Stopka <mark.stopka@perlur.cloud>",
   "Pavel Šimerda <pavel.simerda@perlur.cloud>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cardano_ouroboros_network"
+description = "This crate implements the networking layer for the Ouroboros protocol used by Cardano blockchain."
 license = "GPL-3.0 OR LGPL-3.0-only"
 version = "0.2.2"
 authors = [


### PR DESCRIPTION
- Remove redundant build in the crate publishing job
- Bump-up version to 0.2.2
- Add crate description required by crates.io